### PR TITLE
Support apostrophe

### DIFF
--- a/HongKongKeyboard/Buttons/HongKongKeyboardButton.swift
+++ b/HongKongKeyboard/Buttons/HongKongKeyboardButton.swift
@@ -64,6 +64,7 @@ private extension KeyboardAction {
         case .newLine: return "return"
         case .shift, .shiftDown: return "⇧"
         case .space: return "粵語拼音"
+        case .function: return "'詞"
         case let .switchToKeyboard(type): return buttonText(for: type)
         default: return nil
         }
@@ -83,6 +84,7 @@ private extension KeyboardAction {
         case .none: return 10
         case .shift, .shiftDown, .backspace: return 60
         case let .character(char) where "，。".contains(char): return 20
+        case .function: return 30
         case .switchKeyboard: return 30
         case .space: return 100
         default: return 50

--- a/HongKongKeyboard/HongKongKeyboardActionHandler.swift
+++ b/HongKongKeyboard/HongKongKeyboardActionHandler.swift
@@ -124,8 +124,8 @@ private extension HongKongKeyboardActionHandler {
         }
     }
 
-    func handleApostrophe(for view: UIView) -> GestureAction {
-        return { [weak self] in
+    func handleApostrophe(for _: UIView) -> GestureAction {
+        { [weak self] in
             self?.inputTools.append("'") { currentWord, input, result in
                 self?.handleGoogleInputResult(currentWord: currentWord, input: input, result: result)
             }

--- a/HongKongKeyboard/HongKongKeyboardActionHandler.swift
+++ b/HongKongKeyboard/HongKongKeyboardActionHandler.swift
@@ -42,6 +42,7 @@ class HongKongKeyboardActionHandler: StandardKeyboardActionHandler {
         case .space: return handleSpace(for: view)
         case .backspace: return handleBackspace(for: view)
         case .newLine: return handleNewline(for: view)
+        case .function: return handleApostrophe(for: view)
         case let .switchToKeyboard(type): return { [weak self] in self?.keyboardViewController?.keyboardType = type }
         default: return super.tapAction(for: action, view: view)
         }
@@ -119,6 +120,14 @@ private extension HongKongKeyboardActionHandler {
                     baseAction?()
                 }
             default: return
+            }
+        }
+    }
+
+    func handleApostrophe(for view: UIView) -> GestureAction {
+        return { [weak self] in
+            self?.inputTools.append("'") { currentWord, input, result in
+                self?.handleGoogleInputResult(currentWord: currentWord, input: input, result: result)
             }
         }
     }

--- a/HongKongKeyboard/Keyboards/AlphabeticKeyboard.swift
+++ b/HongKongKeyboard/Keyboards/AlphabeticKeyboard.swift
@@ -43,6 +43,8 @@ private extension AlphabeticKeyboard {
 private extension Sequence where Iterator.Element == KeyboardActionRow {
     func addingSideActions(uppercased: Bool) -> [Iterator.Element] {
         var result = map { $0 }
+        result[1].append(.none)
+        result[1].append(.function)
         result[2].insert(uppercased ? .shiftDown : .shift, at: 0)
         result[2].insert(.none, at: 1)
         result[2].append(.none)


### PR DESCRIPTION
From Google Input Tools:

"You can use ' to explicitly separates pronunciation of two characters.
For example, "long" can be interpreted into "long" or "lo-ng", while
"lo'ng" will only be interpreted into "lo-ng"."